### PR TITLE
Update compile to use newer ruby version present in cedar-14

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ status() {
 
 # Install compass
 status "Installing Compass"
-export GEM_HOME=$BUILD_DIR/ruby/.gem/ruby/1.9.1
+export GEM_HOME=$BUILD_DIR/ruby/.gem/ruby/2.2.0
 PATH="$GEM_HOME/bin:$PATH"
 if [ ! -f $GEM_HOME/bin/compass ]; then
   mkdir -p $BUILD_DIR/ruby


### PR DESCRIPTION
This updates the ruby version, otherwise you'l get: 
WARNING:  You don't have /tmp/build_f391c28786b68e31c1df93dc9247be0d/ruby/.gem/ruby/2.2.0/bin in your PATH, gem executables will not run.

And, for instance, you won't be able to execute "compass", as it will throw the following error: Warning: Couldn't find the `compass` binary. Make sure it's installed and in your $PATH
